### PR TITLE
Allow IdP to return 204 for backend-logout-url feature

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -779,7 +779,7 @@ func (p *OAuthProxy) backendLogout(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != 200 && resp.StatusCode != 204 {
 		logger.Errorf("error while calling backend logout url, returned error code %v", resp.StatusCode)
 	}
 }


### PR DESCRIPTION
IdP returns a 204 NO CONTENT, which I can see matches an expected response code based on the OIDC specs (https://openid.net/specs/openid-connect-backchannel-1_0.html#BCResponse)

## Description

We want to use this logout feature but we need to allow a 204 response code coming from our Identity Provider. Specs suggest we should consider 204 responses as well.

## Motivation and Context

This won't break existing integrations and will allow integration with other IdPs.

## How Has This Been Tested?
I haven't tested the change, but I have tested the integration with the backend-logout-url configuration. Although backend logout happens successfully (as IdP returns 204), we can see that the error message is logged ("error while calling backend logout url, returned error code 204"), which can be confusing and misleading, as user's session has been effectively done.

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
